### PR TITLE
adds clientSort param to table config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Prima Design System public package for `elm`.
 It helps to build scalable UIs by mantaining consistency between design and components across different apps.
 
-Written in `elm@0.19` it follows guidelines defined in [Pyxis](https://pyxis.prima.it).
+Written in `elm@0.19`.
 
 By using `elm`'s type system we can predict behaviors of our components and test them, building strong, scalable ecosystem for our design. 
 

--- a/src/Prima/Pyxis/AtrTable.elm
+++ b/src/Prima/Pyxis/AtrTable.elm
@@ -305,7 +305,7 @@ render (Config ({ atrDetails, alternateRows, isEditable } as config)) =
         rows =
             buildRows isEditable atrDetails
     in
-    Table.render Table.initialState <| Table.config Table.defaultType True headers rows alternateRows
+    Table.render (Table.initialState Nothing Nothing) <| Table.config Table.defaultType True headers rows alternateRows
 
 
 buildHeaders : List String -> List (Table.Header Msg)

--- a/src/Prima/Pyxis/AtrTable.elm
+++ b/src/Prima/Pyxis/AtrTable.elm
@@ -305,7 +305,7 @@ render (Config ({ atrDetails, alternateRows, isEditable } as config)) =
         rows =
             buildRows isEditable atrDetails
     in
-    Table.render Table.initialState <| Table.config Table.defaultType headers rows alternateRows
+    Table.render Table.initialState <| Table.config Table.defaultType True headers rows alternateRows
 
 
 buildHeaders : List String -> List (Table.Header Msg)

--- a/src/Prima/Pyxis/Helpers.elm
+++ b/src/Prima/Pyxis/Helpers.elm
@@ -13,7 +13,7 @@ import Html.Attributes exposing (href, rel)
 
 pyxisStyle : Html msg
 pyxisStyle =
-    Html.node "link" [ href "https://d3be8952cnveif.cloudfront.net/pyxis/1.8.2/prima.css", rel "stylesheet" ] []
+    Html.node "link" [ href "https://d3be8952cnveif.cloudfront.net/pyxis/1.8.12/prima.css", rel "stylesheet" ] []
 
 
 loremIpsum : String

--- a/src/Prima/Pyxis/Helpers.elm
+++ b/src/Prima/Pyxis/Helpers.elm
@@ -13,7 +13,7 @@ import Html.Attributes exposing (href, rel)
 
 pyxisStyle : Html msg
 pyxisStyle =
-    Html.node "link" [ href "https://d3be8952cnveif.cloudfront.net/pyxis/1.8.12/prima.css", rel "stylesheet" ] []
+    Html.node "link" [ href "https://d3be8952cnveif.cloudfront.net/pyxis/1.8.15/prima.css", rel "stylesheet" ] []
 
 
 loremIpsum : String

--- a/src/Prima/Pyxis/Table.elm
+++ b/src/Prima/Pyxis/Table.elm
@@ -5,6 +5,7 @@ module Prima.Pyxis.Table exposing
     , columnFloat, columnHtml, columnInteger, columnString
     , sortByAsc, sortByDesc, sortByNothing
     , render
+    , customInitialState
     )
 
 {-| Creates a customizable Table component by using predefined Html syntax.
@@ -56,7 +57,7 @@ type Config msg
 
 type alias Configuration msg =
     { tableType : TableType
-    , clientSort : Bool
+    , enableSorting : Bool
     , headers : List (Header msg)
     , rows : List (Row msg)
     , alternateRows : Bool
@@ -86,14 +87,14 @@ type alias Configuration msg =
                 True
 
         in
-        Table.config Table.defaultType headers rows alternateRows
+        Table.config Table.defaultType enableSorting headers rows alternateRows
 
     ...
 
 -}
 config : TableType -> Bool -> List (Header msg) -> List (Row msg) -> Bool -> Config msg
-config tableType clientSort headers rows alternateRows =
-    Config (Configuration tableType clientSort headers rows alternateRows)
+config tableType enableSorting headers rows alternateRows =
+    Config (Configuration tableType enableSorting headers rows alternateRows)
 
 
 {-| Represents the table skin.
@@ -133,6 +134,28 @@ type State
 initialState : State
 initialState =
     State (InternalState Nothing Nothing)
+
+
+{-| Creates an initial State with parameters.
+-}
+customInitialState : String -> String -> State
+customInitialState sortBy sortedColumn =
+    State (InternalState (stringFromSort <| sortBy) (Just sortedColumn))
+
+
+{-| Converts a String to a Maybe Sort
+-}
+stringFromSort : String -> Maybe Sort
+stringFromSort sort =
+    case sort of
+        "Asc" ->
+            Just Asc
+
+        "Desc" ->
+            Just Desc
+
+        _ ->
+            Nothing
 
 
 type alias InternalState =
@@ -314,7 +337,7 @@ render (State ({ sortBy, sortedColumn } as internalState)) (Config conf) =
             (Maybe.withDefault 0 << retrieveHeaderIndexBySlug sortedColumn) conf.headers
 
         sortedRows =
-            if conf.clientSort then
+            if conf.enableSorting then
                 case sortBy of
                     Nothing ->
                         conf.rows

--- a/src/Prima/Pyxis/Table.elm
+++ b/src/Prima/Pyxis/Table.elm
@@ -5,7 +5,7 @@ module Prima.Pyxis.Table exposing
     , columnFloat, columnHtml, columnInteger, columnString
     , sortByAsc, sortByDesc, sortByNothing
     , render
-    , customInitialState
+    , sortAsc, sortDesc
     )
 
 {-| Creates a customizable Table component by using predefined Html syntax.
@@ -129,33 +129,11 @@ type State
     = State InternalState
 
 
-{-| Creates an initial State with no sort applied.
+{-| Creates an initial State defined by Sort and Column.
 -}
-initialState : State
-initialState =
-    State (InternalState Nothing Nothing)
-
-
-{-| Creates an initial State with parameters.
--}
-customInitialState : String -> String -> State
-customInitialState sortBy sortedColumn =
-    State (InternalState (stringFromSort <| sortBy) (Just sortedColumn))
-
-
-{-| Converts a String to a Maybe Sort
--}
-stringFromSort : String -> Maybe Sort
-stringFromSort sort =
-    case sort of
-        "Asc" ->
-            Just Asc
-
-        "Desc" ->
-            Just Desc
-
-        _ ->
-            Nothing
+initialState : Maybe Sort -> Maybe String -> State
+initialState sortBy sortedColumn =
+    State (InternalState sortBy sortedColumn)
 
 
 type alias InternalState =
@@ -167,6 +145,20 @@ type alias InternalState =
 type Sort
     = Asc
     | Desc
+
+
+{-| Exposes Asc.
+-}
+sortAsc : Maybe Sort
+sortAsc =
+    Just Asc
+
+
+{-| Exposes Desc.
+-}
+sortDesc : Maybe Sort
+sortDesc =
+    Just Desc
 
 
 {-| Sorts the column defined by Slug in Asc order.

--- a/src/Prima/Pyxis/Table.elm
+++ b/src/Prima/Pyxis/Table.elm
@@ -57,7 +57,7 @@ type Config msg
 
 type alias Configuration msg =
     { tableType : TableType
-    , enableSorting : Bool
+    , sorting : Bool
     , headers : List (Header msg)
     , rows : List (Row msg)
     , alternateRows : Bool
@@ -87,14 +87,14 @@ type alias Configuration msg =
                 True
 
         in
-        Table.config Table.defaultType enableSorting headers rows alternateRows
+        Table.config Table.defaultType sorting headers rows alternateRows
 
     ...
 
 -}
 config : TableType -> Bool -> List (Header msg) -> List (Row msg) -> Bool -> Config msg
-config tableType enableSorting headers rows alternateRows =
-    Config (Configuration tableType enableSorting headers rows alternateRows)
+config tableType sorting headers rows alternateRows =
+    Config (Configuration tableType sorting headers rows alternateRows)
 
 
 {-| Represents the table skin.
@@ -337,7 +337,7 @@ render (State ({ sortBy, sortedColumn } as internalState)) (Config conf) =
             (Maybe.withDefault 0 << retrieveHeaderIndexBySlug sortedColumn) conf.headers
 
         sortedRows =
-            if conf.enableSorting then
+            if conf.sorting then
                 case sortBy of
                     Nothing ->
                         conf.rows

--- a/src/Prima/Pyxis/Table.elm
+++ b/src/Prima/Pyxis/Table.elm
@@ -352,22 +352,16 @@ renderTHead internalState ({ headers } as conf) =
 renderTH : InternalState -> Header msg -> Html msg
 renderTH { sortBy, sortedColumn } (Header ({ slug, name } as conf)) =
     let
-        sortableAttribute =
+
+        sort : { sortableAttribute : Html.Attribute msg, sortIcon : Html msg }
+        sort =
             case conf.tagger of
                 Just tagger ->
-                    (onClick << tagger) slug
+                    { sortableAttribute = (onClick << tagger) slug, sortIcon = renderSortIcon sortBy slug }
 
                 Nothing ->
-                    attribute "data-unsortable" ""
+                    { sortableAttribute = attribute "data-unsortable" "", sortIcon = text "" }
 
-        sortIcon : Html msg
-        sortIcon =
-            case conf.tagger of
-                Just tagger ->
-                    renderSortIcon sortBy slug
-
-                Nothing ->
-                    text ""
 
         sortColumn : String
         sortColumn =
@@ -380,12 +374,12 @@ renderTH { sortBy, sortedColumn } (Header ({ slug, name } as conf)) =
 
     in
     th
-        (sortableAttribute
+        (sort.sortableAttribute
             :: [ class "m-table__header__item fsSmall"
                ]
         )
         [ text name
-        , if sortColumn == slug then sortIcon else text ""
+        , if sortColumn == slug then sort.sortIcon else text ""
         ]
 
 

--- a/src/Prima/Pyxis/Table.elm
+++ b/src/Prima/Pyxis/Table.elm
@@ -324,6 +324,7 @@ render (State ({ sortBy, sortedColumn } as internalState)) (Config conf) =
 
                     Just Desc ->
                         (List.reverse << sortRows index) conf.rows
+
             else
                 conf.rows
 
@@ -352,7 +353,6 @@ renderTHead internalState ({ headers } as conf) =
 renderTH : InternalState -> Header msg -> Html msg
 renderTH { sortBy, sortedColumn } (Header ({ slug, name } as conf)) =
     let
-
         sort : { sortableAttribute : Html.Attribute msg, sortIcon : Html msg }
         sort =
             case conf.tagger of
@@ -362,7 +362,6 @@ renderTH { sortBy, sortedColumn } (Header ({ slug, name } as conf)) =
                 Nothing ->
                     { sortableAttribute = attribute "data-unsortable" "", sortIcon = text "" }
 
-
         sortColumn : String
         sortColumn =
             case sortedColumn of
@@ -371,7 +370,6 @@ renderTH { sortBy, sortedColumn } (Header ({ slug, name } as conf)) =
 
                 Nothing ->
                     ""
-
     in
     th
         (sort.sortableAttribute
@@ -379,7 +377,11 @@ renderTH { sortBy, sortedColumn } (Header ({ slug, name } as conf)) =
                ]
         )
         [ text name
-        , if sortColumn == slug then sort.sortIcon else text ""
+        , if sortColumn == slug then
+            sort.sortIcon
+
+          else
+            text ""
         ]
 
 

--- a/src/Prima/Pyxis/Table/Examples/Model.elm
+++ b/src/Prima/Pyxis/Table/Examples/Model.elm
@@ -1,7 +1,6 @@
 module Prima.Pyxis.Table.Examples.Model exposing
     ( Model
     , Msg(..)
-    , Sort(..)
     , initialModel
     )
 
@@ -18,7 +17,7 @@ type alias Model =
     , rows : List (List String)
     , tableState : Table.State
     , sortByColumn : Maybe String
-    , sortBy : Maybe Sort
+    , sortBy : Maybe Table.Sort
     }
 
 
@@ -27,7 +26,7 @@ initialModel =
     Model
         initialHeaders
         initialRows
-        Table.initialState
+        (Table.initialState Nothing Nothing)
         Nothing
         Nothing
 
@@ -46,8 +45,3 @@ initialRows =
     , [ "Spagna", "Madrid" ]
     , [ "Olanda", "Amsterdam" ]
     ]
-
-
-type Sort
-    = Asc
-    | Desc

--- a/src/Prima/Pyxis/Table/Examples/Update.elm
+++ b/src/Prima/Pyxis/Table/Examples/Update.elm
@@ -12,20 +12,24 @@ update msg model =
 
         SortBy headerSlug ->
             let
-                ( sortAlgorithm, sortMapper ) =
-                    case model.sortBy of
-                        Nothing ->
-                            ( Just Asc, Table.sortByAsc )
+                sortAlgorithm =
+                    if isNothing model.sortBy then
+                        Table.sortAsc
 
-                        Just Asc ->
-                            ( Just Desc, Table.sortByDesc )
+                    else if model.sortBy == Table.sortAsc then
+                        Table.sortDesc
 
-                        Just Desc ->
-                            ( Nothing, Table.sortByNothing )
+                    else
+                        Nothing
             in
             ( { model
                 | sortBy = sortAlgorithm
-                , tableState = sortMapper headerSlug model.tableState
+                , tableState = Table.sort (Just headerSlug) sortAlgorithm model.tableState
               }
             , Cmd.none
             )
+
+
+isNothing : Maybe Table.Sort -> Bool
+isNothing =
+    (==) Nothing

--- a/src/Prima/Pyxis/Table/Examples/View.elm
+++ b/src/Prima/Pyxis/Table/Examples/View.elm
@@ -25,6 +25,7 @@ createTableConfiguration : Model -> Table.Config Msg
 createTableConfiguration model =
     Table.config
         Table.defaultType
+        True -- clientSort
         (createHeaders model.headers)
         (createRows model.rows)
         True
@@ -32,8 +33,10 @@ createTableConfiguration model =
 
 createHeaders : List String -> List (Table.Header Msg)
 createHeaders headers =
-    List.map createHeaderItem headers
-
+    -- List.map createHeaderItem headers
+    [ Table.header (String.toLower "Nazione") "Nazione" (Just SortBy)
+    , Table.header (String.toLower "Paese") "Paese" (Just SortBy)
+    ]
 
 createHeaderItem : String -> Table.Header Msg
 createHeaderItem content =

--- a/src/Prima/Pyxis/Table/Examples/View.elm
+++ b/src/Prima/Pyxis/Table/Examples/View.elm
@@ -25,7 +25,7 @@ createTableConfiguration : Model -> Table.Config Msg
 createTableConfiguration model =
     Table.config
         Table.defaultType
-        True -- clientSort
+        True
         (createHeaders model.headers)
         (createRows model.rows)
         True
@@ -33,10 +33,10 @@ createTableConfiguration model =
 
 createHeaders : List String -> List (Table.Header Msg)
 createHeaders headers =
-    -- List.map createHeaderItem headers
     [ Table.header (String.toLower "Nazione") "Nazione" (Just SortBy)
     , Table.header (String.toLower "Paese") "Paese" (Just SortBy)
     ]
+
 
 createHeaderItem : String -> Table.Header Msg
 createHeaderItem content =


### PR DESCRIPTION
La configurazione di table adesso riceve anche un Bool "clientSort". Se si passa False il sort può essere gestito dal server.
Le icone vengono gestite comunque passando "tagger".
Se la colonna non ha tagger adesso non viene sortata.