### PR TITLE
Table render with attributes

### DIFF
--- a/src/Prima/Pyxis/Table/Examples/View.elm
+++ b/src/Prima/Pyxis/Table/Examples/View.elm
@@ -1,10 +1,12 @@
 module Prima.Pyxis.Table.Examples.View exposing (view)
 
 import Browser
-import Html exposing (Html)
+import Html exposing (Html, h3, text)
+import Html.Attributes exposing (style)
 import Prima.Pyxis.Helpers as Helpers
 import Prima.Pyxis.Table as Table
 import Prima.Pyxis.Table.Examples.Model exposing (..)
+import Prima.Pyxis.Table.TableWithAttributes as Table
 
 
 view : Model -> Browser.Document Msg
@@ -17,7 +19,12 @@ view model =
 appBody : Model -> List (Html Msg)
 appBody model =
     [ Helpers.pyxisStyle
+    , h3 [] [ text "Table" ]
     , (Table.render model.tableState << createTableConfiguration) model
+    , h3 [] [ text "Table with attributes" ]
+    , Table.renderWithAttributes model.tableState
+        (createTableConfiguration model)
+        [ Table.tableAttributes [ style "background-color" "antiquewhite" ] ]
     ]
 
 

--- a/src/Prima/Pyxis/Table/Examples/View.elm
+++ b/src/Prima/Pyxis/Table/Examples/View.elm
@@ -24,7 +24,7 @@ appBody model =
     , h3 [] [ text "Table with attributes" ]
     , Table.renderWithAttributes model.tableState
         (createTableConfiguration model)
-        [ Table.tableAttributes [ style "background-color" "antiquewhite" ] ]
+        [ Table.headerAttributes [ style "background-color" "black", style "color" "white" ] ]
     ]
 
 

--- a/src/Prima/Pyxis/Table/TableWithAttributes.elm
+++ b/src/Prima/Pyxis/Table/TableWithAttributes.elm
@@ -1,0 +1,30 @@
+module Prima.Pyxis.Table.TableWithAttributes exposing (..)
+
+import Html exposing (Attribute, Html)
+
+
+type alias AttributeConfiguration msg =
+    { position : AttributeConfigurationPosition
+    , attributes : List (Attribute msg)
+    }
+
+
+type AttributeConfigurationPosition
+    = AttributePositionBody
+    | AttributePositionHeader
+    | AttributePositionTable
+
+
+headerAttributes : List (Attribute msg) -> AttributeConfiguration msg
+headerAttributes =
+    AttributeConfiguration AttributePositionHeader
+
+
+bodyAttributes : List (Attribute msg) -> AttributeConfiguration msg
+bodyAttributes =
+    AttributeConfiguration AttributePositionBody
+
+
+tableAttributes : List (Attribute msg) -> AttributeConfiguration msg
+tableAttributes =
+    AttributeConfiguration AttributePositionTable


### PR DESCRIPTION
Aggiunge una funzione renderTableWithAttributes per avere la possibilità di aggiungere attributi al body, all'head o a tutta la table.