### PR TITLE
Select component: adds placeholder to the choices list for mobile

### DIFF
--- a/src/Prima/Pyxis/Form/Select.elm
+++ b/src/Prima/Pyxis/Form/Select.elm
@@ -547,13 +547,14 @@ renderSelect model ((State { choices }) as stateModel) selectModel =
     let
         options =
             computeOptions selectModel
-
-        choicesWithPlaceholder =
-            SelectChoice "" options.placeholder :: choices
     in
     Html.select
         (buildAttributes model stateModel selectModel)
-        (List.map (renderSelectChoice stateModel) choicesWithPlaceholder)
+        (options.placeholder
+            |> SelectChoice ""
+            |> H.flip (::) choices
+            |> List.map (renderSelectChoice stateModel)
+        )
 
 
 renderSelectChoice : State -> SelectChoice -> Html Msg

--- a/src/Prima/Pyxis/Form/Select.elm
+++ b/src/Prima/Pyxis/Form/Select.elm
@@ -544,9 +544,16 @@ render model stateModel selectModel =
 
 renderSelect : model -> State -> Select model -> Html Msg
 renderSelect model ((State { choices }) as stateModel) selectModel =
+    let
+        options =
+            computeOptions selectModel
+
+        choicesWithPlaceholder =
+            SelectChoice "" options.placeholder :: choices
+    in
     Html.select
         (buildAttributes model stateModel selectModel)
-        (List.map (renderSelectChoice stateModel) choices)
+        (List.map (renderSelectChoice stateModel) choicesWithPlaceholder)
 
 
 renderSelectChoice : State -> SelectChoice -> Html Msg


### PR DESCRIPTION
In the select component, it is necessary to add the placeholder to the choices list to track correctly the pristine/touched status of the select. This pull request adds the placeholder to the options list for mobile.