### PR TITLE
tolto evento in caso di clic su label o input già selezionato

### DIFF
--- a/src/Prima/Pyxis/Form/Example/Update.elm
+++ b/src/Prima/Pyxis/Form/Example/Update.elm
@@ -13,7 +13,7 @@ import Task
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-    case Debug.log "msg" msg of
+    case msg of
         AutocompleteMsg subMsg ->
             let
                 ( autocompleteState, autocompleteCmd, filter ) =

--- a/src/Prima/Pyxis/Form/Example/Update.elm
+++ b/src/Prima/Pyxis/Form/Example/Update.elm
@@ -13,7 +13,7 @@ import Task
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-    case msg of
+    case Debug.log "msg" msg of
         AutocompleteMsg subMsg ->
             let
                 ( autocompleteState, autocompleteCmd, filter ) =

--- a/src/Prima/Pyxis/Form/Radio.elm
+++ b/src/Prima/Pyxis/Form/Radio.elm
@@ -44,6 +44,7 @@ module Prima.Pyxis.Form.Radio exposing
 import Html exposing (Attribute, Html)
 import Html.Attributes as Attrs
 import Html.Events as Events
+import Maybe.Extra
 import Prima.Pyxis.Form.Label as Label
 import Prima.Pyxis.Form.Validation as Validation
 import Prima.Pyxis.Helpers as H
@@ -258,10 +259,18 @@ validationAttribute model radioModel =
 {-| Composes all the modifiers into a set of `Html.Attribute`(s).
 -}
 buildAttributes : model -> Radio model msg -> RadioChoice -> List (Html.Attribute msg)
-buildAttributes model ((Radio _) as radioModel) choice =
+buildAttributes model ((Radio config) as radioModel) choice =
     let
         options =
             computeOptions radioModel
+
+        taggerAttrList : List (Attribute msg)
+        taggerAttrList =
+            if Just choice.value == config.reader model then
+                []
+
+            else
+                [ taggerAttribute radioModel choice ]
     in
     [ options.id
         |> Maybe.map Attrs.id
@@ -278,7 +287,7 @@ buildAttributes model ((Radio _) as radioModel) choice =
         |> (++) options.attributes
         |> (::) (H.classesAttribute options.class)
         |> (::) (readerAttribute model radioModel choice)
-        |> (::) (taggerAttribute radioModel choice)
+        |> (++) taggerAttrList
         |> (::) (validationAttribute model radioModel)
         |> (::) (Attrs.type_ "radio")
         |> (::) (Attrs.value choice.value)
@@ -306,7 +315,16 @@ render model ((Radio { radioChoices }) as radioModel) =
 
 
 renderRadioChoice : model -> Radio model msg -> RadioChoice -> Html msg
-renderRadioChoice model ((Radio { tagger }) as radioModel) ({ value, label } as choice) =
+renderRadioChoice model ((Radio { tagger, reader }) as radioModel) ({ value, label } as choice) =
+    let
+        conditionallyAddOnClick : Label.Label msg -> Label.Label msg
+        conditionallyAddOnClick labelInstance =
+            if Just choice.value == reader model then
+                labelInstance
+
+            else
+                Label.withOnClick (tagger value) labelInstance
+    in
     Html.div
         [ Attrs.class "form-radio" ]
         [ Html.input
@@ -314,7 +332,7 @@ renderRadioChoice model ((Radio { tagger }) as radioModel) ({ value, label } as 
             []
         , label
             |> Label.label
-            |> Label.withOnClick (tagger value)
+            |> conditionallyAddOnClick
             |> Label.withFor value
             |> Label.withOverridingClass "form-radio__label"
             |> Label.render

--- a/src/Prima/Pyxis/Form/Radio.elm
+++ b/src/Prima/Pyxis/Form/Radio.elm
@@ -44,7 +44,6 @@ module Prima.Pyxis.Form.Radio exposing
 import Html exposing (Attribute, Html)
 import Html.Attributes as Attrs
 import Html.Events as Events
-import Maybe.Extra
 import Prima.Pyxis.Form.Label as Label
 import Prima.Pyxis.Form.Validation as Validation
 import Prima.Pyxis.Helpers as H

--- a/src/Prima/Pyxis/Form/RadioButton.elm
+++ b/src/Prima/Pyxis/Form/RadioButton.elm
@@ -270,10 +270,18 @@ computeOptions (RadioButton config) =
 {-| Internal. Transforms all the customizations into a list of valid Html.Attribute(s).
 -}
 buildAttributes : model -> RadioButton model msg -> RadioButtonChoice -> List (Html.Attribute msg)
-buildAttributes model radioButtonModel choice =
+buildAttributes model ((RadioButton config) as radioButtonModel) choice =
     let
         options =
             computeOptions radioButtonModel
+
+        taggerAttrList : List (Attribute msg)
+        taggerAttrList =
+            if Just choice.value == config.reader model then
+                []
+
+            else
+                [ taggerAttribute radioButtonModel choice ]
     in
     [ options.id
         |> Maybe.map Attrs.id
@@ -286,7 +294,7 @@ buildAttributes model radioButtonModel choice =
         |> (++) options.attributes
         |> (::) (H.classesAttribute options.class)
         |> (::) (readerAttribute model radioButtonModel choice)
-        |> (::) (taggerAttribute radioButtonModel choice)
+        |> (++) taggerAttrList
         |> (::) (validationAttribute model radioButtonModel)
         |> (::) (hasSubtitleAttribute choice)
 


### PR DESCRIPTION
Abbiamo notato che per i componenti del form Radio e RadioFlag, veniva lanciato l'evento di update anche se in realtà era stato cliccato lo stesso valore selezionato precendetemente.

Credo il problema sia solo con questi due, perchè la select si comporta correttamente di suo (il browser non lancia eventi).