### PR TITLE
Check validation for Form fields

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "primait/pyxis-components",
     "summary": "Prima Design System components",
     "license": "BSD-3-Clause",
-    "version": "7.1.0",
+    "version": "7.2.0",
     "exposed-modules": [
         "Prima.Pyxis.Accordion",
         "Prima.Pyxis.AtrTable",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "analyse": "./node_modules/.bin/elm-analyse  src/*",
     "review": "./node_modules/.bin/elm-review --compiler node_modules/.bin/elm",
-    "test": "./node_modules/.bin/elm-test"
+    "test": "./node_modules/.bin/elm-test",
+    "serve": "./node_modules/.bin/elm reactor",
+    "serve:doc": "./node_modules/.bin/elm make --docs=docs.json"
   },
   "devDependencies": {
     "elm-review": "^2.1.0"

--- a/src/Prima/Pyxis/Form/Autocomplete.elm
+++ b/src/Prima/Pyxis/Form/Autocomplete.elm
@@ -710,11 +710,11 @@ isPristine (State stateConfig) inputModel =
         ( True, _ ) ->
             True
 
-        ( False, Just _ ) ->
-            False
-
         ( False, Nothing ) ->
             True
+
+        ( False, Just _ ) ->
+            False
 
 
 {-| Internal. Applies the `pristine/touched` visual state to the component.

--- a/src/Prima/Pyxis/Form/Autocomplete.elm
+++ b/src/Prima/Pyxis/Form/Autocomplete.elm
@@ -701,8 +701,20 @@ isPristine (State stateConfig) inputModel =
     let
         options =
             computeOptions inputModel
+
+        sameDefault : Bool
+        sameDefault =
+            Value stateConfig.selected == options.defaultValue
     in
-    Value stateConfig.selected == options.defaultValue
+    case ( sameDefault, stateConfig.selected ) of
+        ( True, _ ) ->
+            True
+
+        ( False, Just _ ) ->
+            False
+
+        ( False, Nothing ) ->
+            True
 
 
 {-| Internal. Applies the `pristine/touched` visual state to the component.
@@ -760,8 +772,9 @@ render model ((State stateConfig) as stateModel) autocompleteModel =
                 |> pickChoices
                 |> List.any (isChoiceSelected stateModel)
 
+        hasValidations : Bool
         hasValidations =
-            List.length options.validations > 0 || not (isPristine stateModel autocompleteModel)
+            (List.length options.validations > 0 && not (isPristine stateModel autocompleteModel)) || not (isPristine stateModel autocompleteModel)
 
         isDisabled : Bool
         isDisabled =
@@ -869,8 +882,9 @@ buildAttributes model stateModel autocompleteModel =
         options =
             computeOptions autocompleteModel
 
+        hasValidations : Bool
         hasValidations =
-            List.length options.validations > 0 || not (isPristine stateModel autocompleteModel)
+            (List.length options.validations > 0 && not (isPristine stateModel autocompleteModel)) || not (isPristine stateModel autocompleteModel)
     in
     [ options.id
         |> Maybe.map Attrs.id

--- a/src/Prima/Pyxis/Form/Autocomplete.elm
+++ b/src/Prima/Pyxis/Form/Autocomplete.elm
@@ -714,12 +714,8 @@ isPristine (State stateConfig) inputModel =
     let
         options =
             computeOptions inputModel
-
-        sameDefault : Bool
-        sameDefault =
-            Value stateConfig.selected == options.defaultValue
     in
-    case ( sameDefault, stateConfig.selected ) of
+    case ( Value stateConfig.selected == options.defaultValue, stateConfig.selected ) of
         ( True, _ ) ->
             True
 

--- a/src/Prima/Pyxis/Form/Autocomplete.elm
+++ b/src/Prima/Pyxis/Form/Autocomplete.elm
@@ -774,7 +774,7 @@ render model ((State stateConfig) as stateModel) autocompleteModel =
 
         hasValidations : Bool
         hasValidations =
-            (List.length options.validations > 0 && not (isPristine stateModel autocompleteModel)) || not (isPristine stateModel autocompleteModel)
+            (List.length options.validations > 0) || not (isPristine stateModel autocompleteModel)
 
         isDisabled : Bool
         isDisabled =
@@ -819,7 +819,7 @@ render model ((State stateConfig) as stateModel) autocompleteModel =
         , renderResetIcon
             |> H.renderIf (hasSelectedAnyChoice && not isDisabled)
         ]
-        :: renderValidationMessages model autocompleteModel
+        :: renderValidationMessages model autocompleteModel hasValidations
 
 
 renderAutocompleteChoice : State -> AutocompleteChoice -> Html Msg
@@ -857,8 +857,8 @@ renderResetIcon =
 
 {-| Internal. Renders the list of errors if present. Renders the list of warnings if not.
 -}
-renderValidationMessages : model -> Autocomplete model -> List (Html Msg)
-renderValidationMessages model autocompleteModel =
+renderValidationMessages : model -> Autocomplete model -> Bool -> List (Html Msg)
+renderValidationMessages model autocompleteModel showValidation =
     let
         warnings =
             warningValidations model (computeOptions autocompleteModel)
@@ -866,12 +866,15 @@ renderValidationMessages model autocompleteModel =
         errors =
             errorsValidations model (computeOptions autocompleteModel)
     in
-    case ( errors, warnings ) of
-        ( [], _ ) ->
+    case ( showValidation, errors, warnings ) of
+        ( True, [], _ ) ->
             List.map Validation.render warnings
 
-        ( _, _ ) ->
+        ( True, _, _ ) ->
             List.map Validation.render errors
+
+        ( False, _, _ ) ->
+            []
 
 
 {-| Internal. Transforms all the customizations into a list of valid Html.Attribute(s).
@@ -884,7 +887,7 @@ buildAttributes model stateModel autocompleteModel =
 
         hasValidations : Bool
         hasValidations =
-            (List.length options.validations > 0 && not (isPristine stateModel autocompleteModel)) || not (isPristine stateModel autocompleteModel)
+            (List.length options.validations > 0) || not (isPristine stateModel autocompleteModel)
     in
     [ options.id
         |> Maybe.map Attrs.id

--- a/src/Prima/Pyxis/Form/Date.elm
+++ b/src/Prima/Pyxis/Form/Date.elm
@@ -641,8 +641,20 @@ isPristine model ((Date config) as dateModel) =
     let
         options =
             computeOptions dateModel
+
+        sameDefault : Bool
+        sameDefault =
+            Value (config.reader model) == options.defaultValue
     in
-    Value (config.reader model) == options.defaultValue
+    case ( sameDefault, config.reader model ) of
+        ( True, _ ) ->
+            True
+
+        ( False, Just _ ) ->
+            False
+
+        ( False, Nothing ) ->
+            True
 
 
 {-| Internal. Applies the `pristine/touched` visual state to the component.
@@ -665,7 +677,7 @@ buildAttributes mode model dateModel =
             computeOptions dateModel
 
         hasValidations =
-            List.length options.validations > 0 || not (isPristine model dateModel)
+            (List.length options.validations > 0 && not (isPristine model dateModel)) || not (isPristine model dateModel)
     in
     [ options.id
         |> Maybe.map Attrs.id

--- a/src/Prima/Pyxis/Form/Date.elm
+++ b/src/Prima/Pyxis/Form/Date.elm
@@ -665,12 +665,8 @@ isPristine model ((Date config) as dateModel) =
     let
         options =
             computeOptions dateModel
-
-        sameDefault : Bool
-        sameDefault =
-            Value (config.reader model) == options.defaultValue
     in
-    case ( sameDefault, config.reader model ) of
+    case ( Value (config.reader model) == options.defaultValue, config.reader model ) of
         ( True, _ ) ->
             True
 

--- a/src/Prima/Pyxis/Form/Date.elm
+++ b/src/Prima/Pyxis/Form/Date.elm
@@ -650,11 +650,11 @@ isPristine model ((Date config) as dateModel) =
         ( True, _ ) ->
             True
 
-        ( False, DatePicker.ParsedDate _ ) ->
-            False
-
         ( False, DatePicker.PartialDate _ ) ->
             True
+
+        ( False, DatePicker.ParsedDate _ ) ->
+            False
 
 
 {-| Internal. Applies the `pristine/touched` visual state to the component.

--- a/src/Prima/Pyxis/Form/Date.elm
+++ b/src/Prima/Pyxis/Form/Date.elm
@@ -2,11 +2,10 @@ module Prima.Pyxis.Form.Date exposing
     ( Date
     , date
     , render
-    , withAttribute, withClass, withDefaultValue, withDisabled, withId, withMediumSize, withSmallSize, withLargeSize, withName, withPlaceholder
+    , withAttribute, withClass, withDefaultValue, withDisabled, withId, withMediumSize, withSmallSize, withLargeSize, withName, withPlaceholder, withIsSubmitted
     , withDatePicker, withDatePickerVisibility
     , withOnBlur, withOnFocus, withOnIconClick
     , withValidation
-    , whitIsSubmitted
     )
 
 {-|
@@ -29,7 +28,7 @@ module Prima.Pyxis.Form.Date exposing
 
 ## Options
 
-@docs withAttribute, withClass, withDefaultValue, withDisabled, withId, withMediumSize, withSmallSize, withLargeSize, withName, withPlaceholder
+@docs withAttribute, withClass, withDefaultValue, withDisabled, withId, withMediumSize, withSmallSize, withLargeSize, withName, withPlaceholder, withIsSubmitted
 
 
 ## DatePicker Options
@@ -177,8 +176,8 @@ withId id =
 
 {-| Adds an `isSubmitted` predicate to the `Date`.
 -}
-whitIsSubmitted : (model -> Bool) -> Date model msg -> Date model msg
-whitIsSubmitted isSubmitted =
+withIsSubmitted : (model -> Bool) -> Date model msg -> Date model msg
+withIsSubmitted isSubmitted =
     addOption (IsSubmitted isSubmitted)
 
 

--- a/src/Prima/Pyxis/Form/Date.elm
+++ b/src/Prima/Pyxis/Form/Date.elm
@@ -650,10 +650,10 @@ isPristine model ((Date config) as dateModel) =
         ( True, _ ) ->
             True
 
-        ( False, Just _ ) ->
+        ( False, DatePicker.ParsedDate _ ) ->
             False
 
-        ( False, Nothing ) ->
+        ( False, DatePicker.PartialDate _ ) ->
             True
 
 

--- a/src/Prima/Pyxis/Form/Example/FieldConfig.elm
+++ b/src/Prima/Pyxis/Form/Example/FieldConfig.elm
@@ -126,7 +126,6 @@ addressWithDefaultConfig =
     Input.text .address (OnInput Address)
         |> Input.withId slug
         |> Input.withDefaultValue (Just "Address")
-        |> Input.withValidation (Validation.notEmptyValidation .address)
         |> Form.input
         |> Form.withLabel
             ("Address"

--- a/src/Prima/Pyxis/Form/Example/FieldConfig.elm
+++ b/src/Prima/Pyxis/Form/Example/FieldConfig.elm
@@ -1,5 +1,6 @@
 module Prima.Pyxis.Form.Example.FieldConfig exposing
-    ( birthDateCompoundConfig
+    ( addressWithDefaultConfig
+    , birthDateCompoundConfig
     , birthDateConfig
     , checkboxConfig
     , countryAutocompleteConfig
@@ -113,6 +114,24 @@ passwordGroupConfig =
                 |> Label.label
                 |> Label.withFor slug
                 |> Label.withSubtitle "(opzionale)"
+            )
+
+
+addressWithDefaultConfig : Form.FormField FormData Msg
+addressWithDefaultConfig =
+    let
+        slug =
+            "address"
+    in
+    Input.text .address (OnInput Address)
+        |> Input.withId slug
+        |> Input.withDefaultValue (Just "Address")
+        |> Input.withValidation (Validation.notEmptyValidation .address)
+        |> Form.input
+        |> Form.withLabel
+            ("Address"
+                |> Label.label
+                |> Label.withFor slug
             )
 
 

--- a/src/Prima/Pyxis/Form/Example/Model.elm
+++ b/src/Prima/Pyxis/Form/Example/Model.elm
@@ -47,6 +47,7 @@ initialModel =
 type Field
     = Username
     | Password
+    | Address
     | Privacy
     | GuideType
     | FiscalCode
@@ -68,6 +69,7 @@ type BirthDateField
 type alias FormData =
     { username : Maybe String
     , password : Maybe String
+    , address : Maybe String
     , privacy : Maybe Bool
     , guideType : Maybe String
     , powerSource : Maybe String
@@ -94,6 +96,7 @@ initialFormData : FormData
 initialFormData =
     { username = Nothing
     , password = Nothing
+    , address = Nothing
     , privacy = Nothing
     , guideType = Nothing
     , powerSource = Nothing

--- a/src/Prima/Pyxis/Form/Example/Update.elm
+++ b/src/Prima/Pyxis/Form/Example/Update.elm
@@ -59,6 +59,11 @@ update msg model =
                 |> updateUsername (H.validString value)
                 |> H.withoutCmds
 
+        OnInput Address value ->
+            model
+                |> updateAddress (H.validString value)
+                |> H.withoutCmds
+
         OnInput Password value ->
             model
                 |> updatePassword (Just value)
@@ -161,6 +166,11 @@ updateSelect selectMsg =
 updateUsername : Maybe String -> Model -> Model
 updateUsername value =
     updateFormData (\f -> { f | username = value })
+
+
+updateAddress : Maybe String -> Model -> Model
+updateAddress value =
+    updateFormData (\f -> { f | address = value })
 
 
 updatePassword : Maybe String -> Model -> Model

--- a/src/Prima/Pyxis/Form/Example/View.elm
+++ b/src/Prima/Pyxis/Form/Example/View.elm
@@ -60,6 +60,9 @@ formConfig model =
         |> Form.withFields
             [ Config.fiscalCodeGroupConfig
             ]
+        |> Form.withFields
+            [ Config.addressWithDefaultConfig
+            ]
         |> Form.withFieldsAndLegend
             (Form.legendWithAppendableHtml
                 "Privacy"

--- a/src/Prima/Pyxis/Form/FilterableSelect.elm
+++ b/src/Prima/Pyxis/Form/FilterableSelect.elm
@@ -3,7 +3,7 @@ module Prima.Pyxis.Form.FilterableSelect exposing
     , filterableSelect, init, initWithDefault, update, filterableSelectChoice
     , render
     , selectedValue, filterValue, subscription, open, close, isOpen, toggle, reset
-    , withAttribute, withClass, withDefaultValue, withDisabled, withId, withName, withMediumSize, withSmallSize, withLargeSize, withPlaceholder, withOverridingClass, withThreshold
+    , withAttribute, withClass, withDefaultValue, withDisabled, withId, withName, withMediumSize, withSmallSize, withLargeSize, withPlaceholder, withOverridingClass, withThreshold, withIsSubmitted
     , withOnBlur, withOnFocus
     , withValidation
     )
@@ -33,7 +33,7 @@ module Prima.Pyxis.Form.FilterableSelect exposing
 
 ## Options
 
-@docs withAttribute, withClass, withDefaultValue, withDisabled, withId, withName, withMediumSize, withSmallSize, withLargeSize, withPlaceholder, withOverridingClass, withThreshold
+@docs withAttribute, withClass, withDefaultValue, withDisabled, withId, withName, withMediumSize, withSmallSize, withLargeSize, withPlaceholder, withOverridingClass, withThreshold, withIsSubmitted
 
 
 ## Event Options
@@ -250,6 +250,13 @@ withDisabled =
 withId : String -> FilterableSelect model -> FilterableSelect model
 withId =
     Autocomplete.withId
+
+
+{-| Adds an `isSubmitted` predicate to the `Autocomplete`.
+-}
+withIsSubmitted : (model -> Bool) -> FilterableSelect model -> FilterableSelect model
+withIsSubmitted =
+    Autocomplete.withIsSubmitted
 
 
 {-| Adds a `name` Html.Attribute to the `FilterableSelect`.

--- a/src/Prima/Pyxis/Form/Input.elm
+++ b/src/Prima/Pyxis/Form/Input.elm
@@ -464,11 +464,14 @@ isPristine model ((Input config) as inputModel) =
         ( True, _ ) ->
             True
 
-        ( False, Just _ ) ->
-            False
+        ( False, Just "" ) ->
+            True
 
         ( False, Nothing ) ->
             True
+
+        ( False, Just _ ) ->
+            False
 
 
 {-| Internal. Applies the `pristine/touched` visual state to the component.

--- a/src/Prima/Pyxis/Form/Input.elm
+++ b/src/Prima/Pyxis/Form/Input.elm
@@ -506,7 +506,7 @@ computeOptions (Input config) =
 {-| Internal. Determines whether the field should be validated or not.
 -}
 shouldBeValidated : model -> Input model msg -> Options model msg -> Bool
-shouldBeValidated model ((Input config) as inputModel) options =
+shouldBeValidated model inputModel options =
     List.length options.validations > 0 || ((not <| isPristine model inputModel) || options.isSubmitted model)
 
 

--- a/src/Prima/Pyxis/Form/Input.elm
+++ b/src/Prima/Pyxis/Form/Input.elm
@@ -507,7 +507,7 @@ computeOptions (Input config) =
 -}
 shouldBeValidated : model -> Input model msg -> Options model msg -> Bool
 shouldBeValidated model inputModel options =
-    List.length options.validations > 0 || ((not <| isPristine model inputModel) || options.isSubmitted model)
+    (not <| isPristine model inputModel) || options.isSubmitted model
 
 
 {-| Internal. Transforms all the customizations into a list of valid Html.Attribute(s).
@@ -558,7 +558,9 @@ buildAttributes model ((Input config) as inputModel) =
         OnInput String
 
     type alias Model =
-        { username: Maybe String }
+        { username : Maybe String
+        , isSubmitted : Bool
+        }
 
     ...
 
@@ -569,6 +571,7 @@ buildAttributes model ((Input config) as inputModel) =
             (Input.email .username OnInput
                 |> Input.withClass "my-custom-class"
                 |> Input.withValidation (Maybe.andThen validate << .username)
+                |> Input.whitIsSubmitted .isSubmitted
             )
 
     validate : String -> Validation.Type

--- a/src/Prima/Pyxis/Form/Input.elm
+++ b/src/Prima/Pyxis/Form/Input.elm
@@ -570,7 +570,7 @@ buildAttributes model ((Input config) as inputModel) =
             (Input.email .username OnInput
                 |> Input.withClass "my-custom-class"
                 |> Input.withValidation (Maybe.andThen validate << .username)
-                |> Input.whitIsSubmitted .isSubmitted
+                |> Input.withIsSubmitted .isSubmitted
             )
 
     validate : String -> Validation.Type

--- a/src/Prima/Pyxis/Form/Input.elm
+++ b/src/Prima/Pyxis/Form/Input.elm
@@ -468,12 +468,8 @@ isPristine model ((Input config) as inputModel) =
     let
         options =
             computeOptions inputModel
-
-        sameDefault : Bool
-        sameDefault =
-            Value (config.reader model) == options.defaultValue
     in
-    case ( sameDefault, config.reader model ) of
+    case ( Value (config.reader model) == options.defaultValue, config.reader model ) of
         ( True, _ ) ->
             True
 

--- a/src/Prima/Pyxis/Form/Input.elm
+++ b/src/Prima/Pyxis/Form/Input.elm
@@ -455,8 +455,20 @@ isPristine model ((Input config) as inputModel) =
     let
         options =
             computeOptions inputModel
+
+        sameDefault : Bool
+        sameDefault =
+            Value (config.reader model) == options.defaultValue
     in
-    Value (config.reader model) == options.defaultValue
+    case ( sameDefault, config.reader model ) of
+        ( True, _ ) ->
+            True
+
+        ( False, Just _ ) ->
+            False
+
+        ( False, Nothing ) ->
+            True
 
 
 {-| Internal. Applies the `pristine/touched` visual state to the component.

--- a/src/Prima/Pyxis/Form/Input.elm
+++ b/src/Prima/Pyxis/Form/Input.elm
@@ -501,7 +501,7 @@ buildAttributes model ((Input config) as inputModel) =
             computeOptions inputModel
 
         hasValidations =
-            List.length options.validations > 0 || not (isPristine model inputModel)
+            (List.length options.validations > 0 && not (isPristine model inputModel)) || (not <| isPristine model inputModel)
     in
     [ options.id
         |> Maybe.map Attrs.id

--- a/src/Prima/Pyxis/Form/Input.elm
+++ b/src/Prima/Pyxis/Form/Input.elm
@@ -2,11 +2,10 @@ module Prima.Pyxis.Form.Input exposing
     ( Input
     , text, password, date, number, email
     , render
-    , withAttribute, withClass, withDefaultValue, withDisabled, withId, withName, withMediumSize, withSmallSize, withLargeSize, withPlaceholder, withOverridingClass
+    , withAttribute, withClass, withDefaultValue, withDisabled, withId, withName, withMediumSize, withSmallSize, withLargeSize, withPlaceholder, withOverridingClass, withIsSubmitted
     , withPrependGroup, withAppendGroup, withGroupClass
     , withOnBlur, withOnFocus
     , withValidation
-    , whitIsSubmitted
     )
 
 {-|
@@ -29,7 +28,7 @@ module Prima.Pyxis.Form.Input exposing
 
 ## Options
 
-@docs withAttribute, withClass, withDefaultValue, withDisabled, withId, withName, withMediumSize, withSmallSize, withLargeSize, withPlaceholder, withOverridingClass
+@docs withAttribute, withClass, withDefaultValue, withDisabled, withId, withName, withMediumSize, withSmallSize, withLargeSize, withPlaceholder, withOverridingClass, withIsSubmitted
 
 
 ## Group Options
@@ -209,8 +208,8 @@ withId id =
 
 {-| Adds an `isSubmitted` predicate to the `Input`.
 -}
-whitIsSubmitted : (model -> Bool) -> Input model msg -> Input model msg
-whitIsSubmitted isSubmitted =
+withIsSubmitted : (model -> Bool) -> Input model msg -> Input model msg
+withIsSubmitted isSubmitted =
     addOption (IsSubmitted isSubmitted)
 
 

--- a/src/Prima/Pyxis/Form/Radio.elm
+++ b/src/Prima/Pyxis/Form/Radio.elm
@@ -255,8 +255,8 @@ validationAttribute model radioModel =
             Attrs.class "has-error"
 
 
-isPristine : model -> Input model msg -> Bool
-isPristine model (Input config) =
+isPristine : model -> Radio model msg -> Bool
+isPristine model (Radio config) =
     case config.reader model of
         Just _ ->
             False

--- a/src/Prima/Pyxis/Form/Radio.elm
+++ b/src/Prima/Pyxis/Form/Radio.elm
@@ -255,6 +255,16 @@ validationAttribute model radioModel =
             Attrs.class "has-error"
 
 
+isPristine : model -> Input model msg -> Bool
+isPristine model (Input config) =
+    case config.reader model of
+        Just _ ->
+            False
+
+        Nothing ->
+            True
+
+
 {-| Composes all the modifiers into a set of `Html.Attribute`(s).
 -}
 buildAttributes : model -> Radio model msg -> RadioChoice -> List (Html.Attribute msg)
@@ -270,6 +280,10 @@ buildAttributes model ((Radio config) as radioModel) choice =
 
             else
                 [ taggerAttribute radioModel choice ]
+
+        hasValidations : Bool
+        hasValidations =
+            (List.length options.validations > 0 && not (isPristine model radioModel)) || not (isPristine model radioModel)
     in
     [ options.id
         |> Maybe.map Attrs.id
@@ -287,7 +301,7 @@ buildAttributes model ((Radio config) as radioModel) choice =
         |> (::) (H.classesAttribute options.class)
         |> (::) (readerAttribute model radioModel choice)
         |> (++) taggerAttrList
-        |> (::) (validationAttribute model radioModel)
+        |> H.addIf hasValidations (validationAttribute model radioModel)
         |> (::) (Attrs.type_ "radio")
         |> (::) (Attrs.value choice.value)
 

--- a/src/Prima/Pyxis/Form/Select.elm
+++ b/src/Prima/Pyxis/Form/Select.elm
@@ -3,7 +3,7 @@ module Prima.Pyxis.Form.Select exposing
     , select, init, initWithDefault, update, selectChoice
     , selectedValue, subscription, open, close, isOpen, toggle, reset
     , render
-    , withAttribute, withId, withDefaultValue, withDisabled, withClass, withLargeSize, withMediumSize, withOverridingClass, withPlaceholder, withSmallSize
+    , withAttribute, withId, withDefaultValue, withDisabled, withClass, withLargeSize, withMediumSize, withOverridingClass, withPlaceholder, withSmallSize, withIsSubmitted
     , withOnBlur, withOnFocus
     , withValidation
     )
@@ -33,7 +33,7 @@ module Prima.Pyxis.Form.Select exposing
 
 ## Options
 
-@docs withAttribute, withId, withDefaultValue, withDisabled, withClass, withLargeSize, withMediumSize, withOverridingClass, withPlaceholder, withSmallSize
+@docs withAttribute, withId, withDefaultValue, withDisabled, withClass, withLargeSize, withMediumSize, withOverridingClass, withPlaceholder, withSmallSize, withIsSubmitted
 
 
 ## Event Options
@@ -274,6 +274,7 @@ type SelectOption model
     | DefaultValue (Maybe String)
     | Disabled Bool
     | Id String
+    | IsSubmitted (model -> Bool)
     | OnFocus Msg
     | OnBlur Msg
     | OverridingClass String
@@ -303,6 +304,7 @@ type alias Options model =
     , defaultValue : Default
     , disabled : Maybe Bool
     , id : Maybe String
+    , isSubmitted : model -> Bool
     , onFocus : Maybe Msg
     , onBlur : Maybe Msg
     , placeholder : String
@@ -318,6 +320,7 @@ defaultOptions =
     , defaultValue = Indeterminate
     , disabled = Nothing
     , id = Nothing
+    , isSubmitted = always True
     , onFocus = Nothing
     , onBlur = Nothing
     , placeholder = "Seleziona"
@@ -374,6 +377,13 @@ withPlaceholder placeholder =
 withId : String -> Select model -> Select model
 withId id =
     addOption (Id id)
+
+
+{-| Adds an `isSubmitted` predicate to the `Input`.
+-}
+withIsSubmitted : (model -> Bool) -> Select model -> Select model
+withIsSubmitted isSubmitted =
+    addOption (IsSubmitted isSubmitted)
 
 
 {-| Sets a `Size` to the `Select`.
@@ -444,6 +454,9 @@ applyOption modifier options =
 
         Id id ->
             { options | id = Just id }
+
+        IsSubmitted predicate ->
+            { options | isSubmitted = predicate }
 
         OnFocus onFocus ->
             { options | onFocus = Just onFocus }
@@ -538,6 +551,13 @@ pristineAttribute state selectModel =
         Attrs.class "is-touched"
 
 
+{-| Internal. Determines whether the field should be validated or not.
+-}
+shouldBeValidated : model -> Select model -> State -> Options model -> Bool
+shouldBeValidated model selectModel stateModel options =
+    (not <| isPristine stateModel selectModel) || options.isSubmitted model
+
+
 {-| Composes all the modifiers into a set of `Html.Attribute`(s).
 -}
 buildAttributes : model -> State -> Select model -> List (Html.Attribute Msg)
@@ -548,7 +568,7 @@ buildAttributes model stateModel selectModel =
 
         hasValidations : Bool
         hasValidations =
-            (List.length options.validations > 0) || not (isPristine stateModel selectModel)
+            shouldBeValidated model selectModel stateModel options
     in
     [ options.id
         |> Maybe.map Attrs.id
@@ -578,7 +598,7 @@ render model stateModel selectModel =
 
         hasValidations : Bool
         hasValidations =
-            (List.length options.validations > 0) || not (isPristine stateModel selectModel)
+            shouldBeValidated model selectModel stateModel options
     in
     [ renderSelect model stateModel selectModel
     , renderCustomSelect model stateModel selectModel
@@ -618,7 +638,7 @@ renderCustomSelect model ((State { choices, isMenuOpen }) as stateModel) selectM
 
         hasValidations : Bool
         hasValidations =
-            (List.length options.validations > 0 && not (isPristine stateModel selectModel)) || not (isPristine stateModel selectModel)
+            shouldBeValidated model selectModel stateModel options
     in
     Html.div
         (H.addIf hasValidations

--- a/src/Prima/Pyxis/Form/Select.elm
+++ b/src/Prima/Pyxis/Form/Select.elm
@@ -520,11 +520,11 @@ isPristine (State stateConfig) selectModel =
         ( True, _ ) ->
             True
 
-        ( False, Just _ ) ->
-            False
-
         ( False, Nothing ) ->
             True
+
+        ( False, Just _ ) ->
+            False
 
 
 {-| Internal. Applies the `pristine/touched` visual state to the component.

--- a/src/Prima/Pyxis/Form/Select.elm
+++ b/src/Prima/Pyxis/Form/Select.elm
@@ -548,7 +548,7 @@ buildAttributes model stateModel selectModel =
 
         hasValidations : Bool
         hasValidations =
-            (List.length options.validations > 0 && not (isPristine stateModel selectModel)) || not (isPristine stateModel selectModel)
+            (List.length options.validations > 0) || not (isPristine stateModel selectModel)
     in
     [ options.id
         |> Maybe.map Attrs.id
@@ -572,10 +572,18 @@ buildAttributes model stateModel selectModel =
 -}
 render : model -> State -> Select model -> List (Html Msg)
 render model stateModel selectModel =
+    let
+        options =
+            computeOptions selectModel
+
+        hasValidations : Bool
+        hasValidations =
+            (List.length options.validations > 0) || not (isPristine stateModel selectModel)
+    in
     [ renderSelect model stateModel selectModel
     , renderCustomSelect model stateModel selectModel
     ]
-        ++ renderValidationMessages model selectModel
+        ++ renderValidationMessages model selectModel hasValidations
 
 
 renderSelect : model -> State -> Select model -> Html Msg
@@ -688,8 +696,8 @@ renderCustomSelectChoice stateModel choice =
         ]
 
 
-renderValidationMessages : model -> Select model -> List (Html Msg)
-renderValidationMessages model selectModel =
+renderValidationMessages : model -> Select model -> Bool -> List (Html Msg)
+renderValidationMessages model selectModel showValidation =
     let
         warnings =
             warningValidations model (computeOptions selectModel)
@@ -697,12 +705,15 @@ renderValidationMessages model selectModel =
         errors =
             errorsValidations model (computeOptions selectModel)
     in
-    case ( errors, warnings ) of
-        ( [], _ ) ->
+    case ( showValidation, errors, warnings ) of
+        ( True, [], _ ) ->
             List.map Validation.render warnings
 
-        ( _, _ ) ->
+        ( True, _, _ ) ->
             List.map Validation.render errors
+
+        ( False, _, _ ) ->
+            []
 
 
 {-| Internal

--- a/src/Prima/Pyxis/Form/Select.elm
+++ b/src/Prima/Pyxis/Form/Select.elm
@@ -507,14 +507,14 @@ validationAttribute model selectModel =
 
 
 isPristine : State -> Select model -> Bool
-isPristine (State { selected }) selectModel =
+isPristine (State stateConfig) selectModel =
     let
         options =
             computeOptions selectModel
 
         sameDefault : Bool
         sameDefault =
-            Value selected == options.defaultValue
+            Value stateConfig.selected == options.defaultValue
     in
     case ( sameDefault, stateConfig.selected ) of
         ( True, _ ) ->

--- a/src/Prima/Pyxis/Form/Select.elm
+++ b/src/Prima/Pyxis/Form/Select.elm
@@ -524,12 +524,8 @@ isPristine (State stateConfig) selectModel =
     let
         options =
             computeOptions selectModel
-
-        sameDefault : Bool
-        sameDefault =
-            Value stateConfig.selected == options.defaultValue
     in
-    case ( sameDefault, stateConfig.selected ) of
+    case ( Value stateConfig.selected == options.defaultValue, stateConfig.selected ) of
         ( True, _ ) ->
             True
 

--- a/src/Prima/Pyxis/Form/Select.elm
+++ b/src/Prima/Pyxis/Form/Select.elm
@@ -511,8 +511,20 @@ isPristine (State { selected }) selectModel =
     let
         options =
             computeOptions selectModel
+
+        sameDefault : Bool
+        sameDefault =
+            Value selected == options.defaultValue
     in
-    Value selected == options.defaultValue
+    case ( sameDefault, stateConfig.selected ) of
+        ( True, _ ) ->
+            True
+
+        ( False, Just _ ) ->
+            False
+
+        ( False, Nothing ) ->
+            True
 
 
 {-| Internal. Applies the `pristine/touched` visual state to the component.
@@ -534,8 +546,9 @@ buildAttributes model stateModel selectModel =
         options =
             computeOptions selectModel
 
+        hasValidations : Bool
         hasValidations =
-            List.length options.validations > 0 || not (isPristine stateModel selectModel)
+            (List.length options.validations > 0 && not (isPristine stateModel selectModel)) || not (isPristine stateModel selectModel)
     in
     [ options.id
         |> Maybe.map Attrs.id
@@ -595,8 +608,9 @@ renderCustomSelect model ((State { choices, isMenuOpen }) as stateModel) selectM
         options =
             computeOptions selectModel
 
+        hasValidations : Bool
         hasValidations =
-            List.length options.validations > 0 || not (isPristine stateModel selectModel)
+            (List.length options.validations > 0 && not (isPristine stateModel selectModel)) || not (isPristine stateModel selectModel)
     in
     Html.div
         (H.addIf hasValidations

--- a/src/Prima/Pyxis/Form/TextArea.elm
+++ b/src/Prima/Pyxis/Form/TextArea.elm
@@ -345,12 +345,8 @@ isPristine model ((TextArea config) as textAreaModel) =
     let
         options =
             computeOptions textAreaModel
-
-        sameDefault : Bool
-        sameDefault =
-            Value (config.reader model) == options.defaultValue
     in
-    case ( sameDefault, config.reader model ) of
+    case ( Value (config.reader model) == options.defaultValue, config.reader model ) of
         ( True, _ ) ->
             True
 

--- a/src/Prima/Pyxis/Form/TextArea.elm
+++ b/src/Prima/Pyxis/Form/TextArea.elm
@@ -341,11 +341,14 @@ isPristine model ((TextArea config) as textAreaModel) =
         ( True, _ ) ->
             True
 
-        ( False, Just _ ) ->
-            False
+        ( False, Just "" ) ->
+            True
 
         ( False, Nothing ) ->
             True
+
+        ( False, Just _ ) ->
+            False
 
 
 {-| Internal. Applies the `pristine/touched` visual state to the component.

--- a/src/Prima/Pyxis/Form/TextArea.elm
+++ b/src/Prima/Pyxis/Form/TextArea.elm
@@ -332,8 +332,20 @@ isPristine model ((TextArea config) as textAreaModel) =
     let
         options =
             computeOptions textAreaModel
+
+        sameDefault : Bool
+        sameDefault =
+            Value (config.reader model) == options.defaultValue
     in
-    Value (config.reader model) == options.defaultValue
+    case ( sameDefault, config.reader model ) of
+        ( True, _ ) ->
+            True
+
+        ( False, Just _ ) ->
+            False
+
+        ( False, Nothing ) ->
+            True
 
 
 {-| Internal. Applies the `pristine/touched` visual state to the component.
@@ -362,8 +374,9 @@ buildAttributes model ((TextArea _) as textAreaModel) =
         options =
             computeOptions textAreaModel
 
+        hasValidations : Bool
         hasValidations =
-            List.length options.validations > 0 || not (isPristine model textAreaModel)
+            (List.length options.validations > 0 && not (isPristine model textAreaModel)) || not (isPristine model textAreaModel)
     in
     [ options.id
         |> Maybe.map Attrs.id


### PR DESCRIPTION
Changelog:
- extends `isPristine` for types `Input` and `TextArea` to verify if the current value is `Nothing | Just "" | Just _` or different to `DefaultValue`
- extends `isPristine` for type `Date` to verify if the current value is `PartialDate _ | ParsedDate _` or different to `DefaultValue`
- extends `isPristine` for types `Select` and `Autocomplete` to verify if the selected value is `Nothing | Just _` or different to `DefaultValue`
- add `withIsSubmitted` to all form fields (default `always True`) The option is a function that receive a model and return a boolean. The field use that bool to determine if it is submitted and then enable validation state.
- add `shouldBeValidated` to check if the field isn't pristine or is submitted
- inserts `addressWithDefault` to `Form` example