### PR TITLE
subscriptions per eventi di tastiera solo sui campi aperti

### DIFF
--- a/src/Prima/Pyxis/Form/Autocomplete.elm
+++ b/src/Prima/Pyxis/Form/Autocomplete.elm
@@ -965,8 +965,7 @@ subscription : State -> Sub Msg
 subscription state =
     if isOpen state then
         Events.keyCode
-            |> Json.Decode.map KeyboardEvents.toKeyCode
-            |> Json.Decode.map OnKeyPress
+            |> Json.Decode.map (OnKeyPress << KeyboardEvents.toKeyCode)
             |> Browser.Events.onKeyDown
 
     else

--- a/src/Prima/Pyxis/Form/Autocomplete.elm
+++ b/src/Prima/Pyxis/Form/Autocomplete.elm
@@ -961,12 +961,16 @@ pickChoiceByIndex index =
 
 {-| Needed to wire keyboard events to the `Autocomplete`.
 -}
-subscription : Sub Msg
-subscription =
-    Events.keyCode
-        |> Json.Decode.map KeyboardEvents.toKeyCode
-        |> Json.Decode.map OnKeyPress
-        |> Browser.Events.onKeyDown
+subscription : State -> Sub Msg
+subscription state =
+    if isOpen state then
+        Events.keyCode
+            |> Json.Decode.map KeyboardEvents.toKeyCode
+            |> Json.Decode.map OnKeyPress
+            |> Browser.Events.onKeyDown
+
+    else
+        Sub.none
 
 
 {-| Internal.

--- a/src/Prima/Pyxis/Form/Example.elm
+++ b/src/Prima/Pyxis/Form/Example.elm
@@ -17,12 +17,11 @@ main =
         , view = view
         , update = update
         , subscriptions =
-            always
-                (Sub.batch
-                    [ Sub.map SelectMsg Select.subscription
-                    , Sub.map AutocompleteMsg Autocomplete.subscription
+            \model ->
+                Sub.batch
+                    [ Sub.map SelectMsg <| Select.subscription model.formData.powerSourceSelect
+                    , Sub.map AutocompleteMsg <| Autocomplete.subscription model.formData.countryAutocomplete
                     ]
-                )
         }
 
 

--- a/src/Prima/Pyxis/Form/FilterableSelect.elm
+++ b/src/Prima/Pyxis/Form/FilterableSelect.elm
@@ -211,7 +211,7 @@ filterValue =
 
 {-| Needed to wire keyboard events to the `FilterableSelect`.
 -}
-subscription : Sub Autocomplete.Msg
+subscription : Autocomplete.State -> Sub Autocomplete.Msg
 subscription =
     Autocomplete.subscription
 

--- a/src/Prima/Pyxis/Form/Select.elm
+++ b/src/Prima/Pyxis/Form/Select.elm
@@ -748,8 +748,7 @@ subscription : State -> Sub Msg
 subscription state =
     if isOpen state then
         Events.keyCode
-            |> Json.Decode.map KeyboardEvents.toKeyCode
-            |> Json.Decode.map OnKeyPress
+            |> Json.Decode.map (OnKeyPress << KeyboardEvents.toKeyCode)
             |> Browser.Events.onKeyDown
 
     else

--- a/src/Prima/Pyxis/Form/Select.elm
+++ b/src/Prima/Pyxis/Form/Select.elm
@@ -744,9 +744,13 @@ pickChoiceByIndex index (State { choices }) =
 
 {-| Needed to wire keyboard events to the `Select`.
 -}
-subscription : Sub Msg
-subscription =
-    Events.keyCode
-        |> Json.Decode.map KeyboardEvents.toKeyCode
-        |> Json.Decode.map OnKeyPress
-        |> Browser.Events.onKeyDown
+subscription : State -> Sub Msg
+subscription state =
+    if isOpen state then
+        Events.keyCode
+            |> Json.Decode.map KeyboardEvents.toKeyCode
+            |> Json.Decode.map OnKeyPress
+            |> Browser.Events.onKeyDown
+
+    else
+        Sub.none


### PR DESCRIPTION
attualmente le subscription agli eventi di tastiera di autocomplete, select e filterable select vengono registrate sempre. Quindi gli eventi arrivano sempre e si può continuare a cambiare il valore di questi campi sempre. Questa PR introduce una breaking change dell'api (chiamare la subscription di questi elementi ora richiede che venga passato il modello) ma si allinea al modo di elm di decidere le subscription basandosi sul model. In più risolve un bug, quindi credo ne valga la pena.