### PR TITLE
[PRIMA-9446]: L'attributo `for` delle label non contiene l'id dell'input a cui fanno riferimento.

### DIFF
--- a/src/Prima/Pyxis/Form/Checkbox.elm
+++ b/src/Prima/Pyxis/Form/Checkbox.elm
@@ -280,7 +280,7 @@ buildAttributes model checkboxModel { label, value } =
             computeOptions checkboxModel
     in
     [ generateId options label
-              |> Maybe.map Attrs.id
+        |> Maybe.map Attrs.id
     , options.name
         |> Maybe.map Attrs.name
     , options.disabled

--- a/src/Prima/Pyxis/Form/Checkbox.elm
+++ b/src/Prima/Pyxis/Form/Checkbox.elm
@@ -326,12 +326,6 @@ render model ((Checkbox config) as checkboxModel) =
 renderCheckbox : model -> Checkbox model msg -> CheckboxChoice -> Html msg
 renderCheckbox model ((Checkbox config) as checkboxModel) ({ value, label } as checkboxItem) =
     let
-        conditionallyAddFor : Label.Label msg -> Label.Label msg
-        conditionallyAddFor =
-            generateId options label
-                |> Maybe.map Label.withFor
-                |> Maybe.withDefault identity
-
         options : Options model msg
         options =
             computeOptions checkboxModel
@@ -344,7 +338,7 @@ renderCheckbox model ((Checkbox config) as checkboxModel) ({ value, label } as c
         , label
             |> Label.label
             |> Label.withOnClick (config.tagger value)
-            |> conditionallyAddFor
+            |> Label.withConditionallyFor (generateId options label)
             |> Label.withOverridingClass "form-checkbox__label"
             |> Label.render
         ]
@@ -352,8 +346,8 @@ renderCheckbox model ((Checkbox config) as checkboxModel) ({ value, label } as c
 
 {-| Internal
 -}
-composeIdBlocks : String -> String -> String
-composeIdBlocks label id =
+toId : String -> String -> String
+toId label id =
     id ++ "_" ++ H.slugify label
 
 
@@ -361,7 +355,7 @@ composeIdBlocks label id =
 -}
 generateId : Options model msg -> String -> Maybe String
 generateId { id } checkboxItemLabel =
-    Maybe.map (composeIdBlocks checkboxItemLabel) id
+    Maybe.map (toId checkboxItemLabel) id
 
 
 warningValidations : model -> Options model msg -> List Validation.Type

--- a/src/Prima/Pyxis/Form/Checkbox.elm
+++ b/src/Prima/Pyxis/Form/Checkbox.elm
@@ -275,15 +275,12 @@ computeOptions (Checkbox config) =
 buildAttributes : model -> Checkbox model msg -> CheckboxChoice -> List (Html.Attribute msg)
 buildAttributes model checkboxModel { label, value } =
     let
+        options : Options model msg
         options =
             computeOptions checkboxModel
-
-        generateId : String -> String
-        generateId id =
-            id ++ "_" ++ H.slugify label
     in
-    [ options.id
-        |> Maybe.map (generateId >> Attrs.id)
+    [ generateId options label
+              |> Maybe.map Attrs.id
     , options.name
         |> Maybe.map Attrs.name
     , options.disabled
@@ -328,6 +325,17 @@ render model ((Checkbox config) as checkboxModel) =
 -}
 renderCheckbox : model -> Checkbox model msg -> CheckboxChoice -> Html msg
 renderCheckbox model ((Checkbox config) as checkboxModel) ({ value, label } as checkboxItem) =
+    let
+        conditionallyAddFor : Label.Label msg -> Label.Label msg
+        conditionallyAddFor =
+            generateId options label
+                |> Maybe.map Label.withFor
+                |> Maybe.withDefault identity
+
+        options : Options model msg
+        options =
+            computeOptions checkboxModel
+    in
     Html.div
         [ Attrs.class "form-checkbox" ]
         [ Html.input
@@ -336,10 +344,24 @@ renderCheckbox model ((Checkbox config) as checkboxModel) ({ value, label } as c
         , label
             |> Label.label
             |> Label.withOnClick (config.tagger value)
-            |> Label.withFor value
+            |> conditionallyAddFor
             |> Label.withOverridingClass "form-checkbox__label"
             |> Label.render
         ]
+
+
+{-| Internal
+-}
+composeIdBlocks : String -> String -> String
+composeIdBlocks label id =
+    id ++ "_" ++ H.slugify label
+
+
+{-| Internal
+-}
+generateId : Options model msg -> String -> Maybe String
+generateId { id } checkboxItemLabel =
+    Maybe.map (composeIdBlocks checkboxItemLabel) id
 
 
 warningValidations : model -> Options model msg -> List Validation.Type

--- a/src/Prima/Pyxis/Form/Label.elm
+++ b/src/Prima/Pyxis/Form/Label.elm
@@ -3,6 +3,7 @@ module Prima.Pyxis.Form.Label exposing
     , label, labelWithHtml
     , render
     , withAttribute, withClass, withFor, withOverridingClass, withSubtitle
+    , withConditionallyFor
     , withOnClick
     )
 
@@ -137,6 +138,16 @@ withClass class =
 withFor : String -> Label msg -> Label msg
 withFor for =
     addOption (For for)
+
+
+{-| Sets a for to the `Label config` if the maybeFor argument has a value,
+    otherwise it leaves the `Label config` unchanged.
+-}
+withConditionallyFor : Maybe String -> Label msg -> Label msg
+withConditionallyFor maybeFor =
+    maybeFor
+        |> Maybe.map withFor
+        |> Maybe.withDefault identity
 
 
 {-| Sets an `onClick` to the `Label config`.

--- a/src/Prima/Pyxis/Form/Radio.elm
+++ b/src/Prima/Pyxis/Form/Radio.elm
@@ -347,12 +347,6 @@ renderRadioChoice model ((Radio { tagger, reader }) as radioModel) ({ value, lab
             else
                 Label.withOnClick (tagger value)
 
-        conditionallyAddFor : Label.Label msg -> Label.Label msg
-        conditionallyAddFor =
-            generateId options label
-                |> Maybe.map Label.withFor
-                |> Maybe.withDefault identity
-
         options : Options model msg
         options =
             computeOptions radioModel
@@ -365,7 +359,7 @@ renderRadioChoice model ((Radio { tagger, reader }) as radioModel) ({ value, lab
         , label
             |> Label.label
             |> conditionallyAddOnClick
-            |> conditionallyAddFor
+            |> Label.withConditionallyFor (generateId options label)
             |> Label.withOverridingClass "form-radio__label"
             |> Label.render
         ]
@@ -397,8 +391,8 @@ computeOptions (Radio { options }) =
 
 {-| Internal
 -}
-composeIdBlocks : String -> String -> String
-composeIdBlocks label id =
+toId : String -> String -> String
+toId label id =
     id ++ "_" ++ H.slugify label
 
 
@@ -406,7 +400,7 @@ composeIdBlocks label id =
 -}
 generateId : Options model msg -> String -> Maybe String
 generateId { id } radioChoiceLabel =
-    Maybe.map (composeIdBlocks radioChoiceLabel) id
+    Maybe.map (toId radioChoiceLabel) id
 
 
 warningValidations : model -> Options model msg -> List Validation.Type

--- a/src/Prima/Pyxis/Form/Radio.elm
+++ b/src/Prima/Pyxis/Form/Radio.elm
@@ -270,6 +270,7 @@ isPristine model (Radio config) =
 buildAttributes : model -> Radio model msg -> RadioChoice -> List (Html.Attribute msg)
 buildAttributes model ((Radio config) as radioModel) ({ label } as choice) =
     let
+        options : Options model msg
         options =
             computeOptions radioModel
 
@@ -284,13 +285,9 @@ buildAttributes model ((Radio config) as radioModel) ({ label } as choice) =
         hasValidations : Bool
         hasValidations =
             (List.length options.validations > 0 && not (isPristine model radioModel)) || not (isPristine model radioModel)
-
-        generateId : String -> String
-        generateId id =
-            id ++ "_" ++ H.slugify label
     in
-    [ options.id
-        |> Maybe.map (generateId >> Attrs.id)
+    [ generateId options label
+        |> Maybe.map Attrs.id
     , options.name
         |> Maybe.map Attrs.name
     , options.disabled
@@ -343,12 +340,22 @@ renderRadioChoice : model -> Radio model msg -> RadioChoice -> Html msg
 renderRadioChoice model ((Radio { tagger, reader }) as radioModel) ({ value, label } as choice) =
     let
         conditionallyAddOnClick : Label.Label msg -> Label.Label msg
-        conditionallyAddOnClick labelInstance =
+        conditionallyAddOnClick =
             if Just choice.value == reader model then
-                labelInstance
+                identity
 
             else
-                Label.withOnClick (tagger value) labelInstance
+                Label.withOnClick (tagger value)
+
+        conditionallyAddFor : Label.Label msg -> Label.Label msg
+        conditionallyAddFor =
+            generateId options label
+                |> Maybe.map Label.withFor
+                |> Maybe.withDefault identity
+
+        options : Options model msg
+        options =
+            computeOptions radioModel
     in
     Html.div
         [ Attrs.class "form-radio" ]
@@ -358,7 +365,7 @@ renderRadioChoice model ((Radio { tagger, reader }) as radioModel) ({ value, lab
         , label
             |> Label.label
             |> conditionallyAddOnClick
-            |> Label.withFor value
+            |> conditionallyAddFor
             |> Label.withOverridingClass "form-radio__label"
             |> Label.render
         ]
@@ -386,6 +393,20 @@ renderValidationMessages model radioModel =
 computeOptions : Radio model msg -> Options model msg
 computeOptions (Radio { options }) =
     List.foldl applyOption defaultOptions options
+
+
+{-| Internal
+-}
+composeIdBlocks : String -> String -> String
+composeIdBlocks label id =
+    id ++ "_" ++ H.slugify label
+
+
+{-| Internal
+-}
+generateId : Options model msg -> String -> Maybe String
+generateId { id } radioChoiceLabel =
+    Maybe.map (composeIdBlocks radioChoiceLabel) id
 
 
 warningValidations : model -> Options model msg -> List Validation.Type

--- a/src/Prima/Pyxis/Form/RadioFlag.elm
+++ b/src/Prima/Pyxis/Form/RadioFlag.elm
@@ -304,7 +304,7 @@ buildAttributes model ((RadioFlag config) as radioModel) ({ label } as choice) =
                 [ taggerAttribute radioModel choice ]
     in
     [ generateId options label
-              |> Maybe.map Attrs.id
+        |> Maybe.map Attrs.id
     , options.name
         |> Maybe.map Attrs.name
     , options.disabled

--- a/src/Prima/Pyxis/Form/RadioFlag.elm
+++ b/src/Prima/Pyxis/Form/RadioFlag.elm
@@ -353,12 +353,6 @@ renderRadioChoice model ((RadioFlag { tagger, skin, reader }) as radioModel) ({ 
             else
                 Label.withOnClick (tagger value)
 
-        conditionallyAddFor : Label.Label msg -> Label.Label msg
-        conditionallyAddFor =
-            generateId options label
-                |> Maybe.map Label.withFor
-                |> Maybe.withDefault identity
-
         options : Options model msg
         options =
             computeOptions radioModel
@@ -376,7 +370,7 @@ renderRadioChoice model ((RadioFlag { tagger, skin, reader }) as radioModel) ({ 
         , label
             |> Label.label
             |> conditionallyAddOnClick
-            |> conditionallyAddFor
+            |> Label.withConditionallyFor (generateId options label)
             |> Label.withOverridingClass "form-radio-flag__label"
             |> Label.render
         ]
@@ -408,8 +402,8 @@ computeOptions (RadioFlag { options }) =
 
 {-| Internal
 -}
-composeIdBlocks : String -> String -> String
-composeIdBlocks label id =
+toId : String -> String -> String
+toId label id =
     id ++ "_" ++ H.slugify label
 
 
@@ -417,7 +411,7 @@ composeIdBlocks label id =
 -}
 generateId : Options model msg -> String -> Maybe String
 generateId { id } radioChoiceLabel =
-    Maybe.map (composeIdBlocks radioChoiceLabel) id
+    Maybe.map (toId radioChoiceLabel) id
 
 
 warningValidations : model -> Options model msg -> List Validation.Type


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PRIMA-9446

Questa pull request modifica il modo in cui viene definito l'attributo "for" dei label associati ad un elemento input in modo tale che il valore dell'attributo "for" del label corrisponda al valore dell'attributo "id" dell'input.

Le modifiche sono state fatte nei punti in cui veniva usata la funzione "Label.withFor" (ad eccezione del file CheckboxFlag.elm che mi sembra già a posto).